### PR TITLE
Update .travis.yml to use build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ notifications:
 
 language: c
 
+# add platforms to build matrix
+env:
+    - PLATFORM=x86
+    - PLATFORM=stm32f0xx
+
 before_script:
   # install GCC ARM from GNU ARM Embedded Toolchain PPA
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
@@ -26,4 +31,4 @@ before_install:
   - git submodule update --init --recursive
 
 script:
-  - make build_all PLATFORM=x86
+  - make build_all PLATFORM=$PLATFORM

--- a/platform/stm32f0xx/platform.mk
+++ b/platform/stm32f0xx/platform.mk
@@ -23,6 +23,7 @@ CDEFINES := USE_STDPERIPH_DRIVER STM32F072
 CFLAGS := -Wall -Werror -g -Os -Wno-unused-variable -pedantic \
           -ffunction-sections -fdata-sections -fno-builtin -flto \
           --specs=nosys.specs --specs=nano.specs \
+		  -std=c99 \
           $(ARCH_CLAGS) $(addprefix -D,$(CDEFINES))
 
 # Linker flags


### PR DESCRIPTION
Added platforms to .travis.yml to make use of the build matrix.

Travis is smart enough to generate all permutations of the build matrix for _Runtime_, _Environment_ and _Exclusions/Inclusions_ variables.