### PR TITLE
Fix linter error for comments

### DIFF
--- a/lint.py
+++ b/lint.py
@@ -2947,11 +2947,9 @@ def CheckComment(line, filename, linenum, next_line_start, error):
       # Allow one space for new scopes, two spaces otherwise:
       if (not (Match(r'^.*{ *//', line) and next_line_start == commentpos) and
           ((commentpos >= 1 and
-            line[commentpos-1] not in string.whitespace) or
-           (commentpos >= 2 and
-            line[commentpos-2] not in string.whitespace))):
+            line[commentpos-1] not in string.whitespace))):
         error(filename, linenum, 'whitespace/comments', 2,
-              'At least two spaces is best between code and comments')
+              'At least one space is needed between code and comments')
 
       # Checks for common mistakes in TODO comments.
       comment = line[commentpos:]


### PR DESCRIPTION
Fix linter error so that it no longer complains when comments on a line don't have 2 spaces (or more)

Also, test to make sure the ``.travis.yml`` fix works.